### PR TITLE
占い結果の履歴を見れるViewを作成(HistoryView)

### DIFF
--- a/Yumemi-intern-coding-assignment.xcodeproj/project.pbxproj
+++ b/Yumemi-intern-coding-assignment.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		4356E0C42C26BC69000760CA /* PersonalRecordHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4356E0C32C26BC69000760CA /* PersonalRecordHistory.swift */; };
 		4356E0C62C26EA61000760CA /* FortuneResponseHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4356E0C52C26EA61000760CA /* FortuneResponseHistory.swift */; };
 		4371F5962C2467F7002A15EC /* FortuneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4371F5952C2467F7002A15EC /* FortuneView.swift */; };
+		43B95D662C27058200004988 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B95D652C27058200004988 /* HistoryView.swift */; };
+		43B95D692C271AB300004988 /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 43B95D682C271AB300004988 /* SDWebImageSwiftUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +59,7 @@
 		4356E0C32C26BC69000760CA /* PersonalRecordHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalRecordHistory.swift; sourceTree = "<group>"; };
 		4356E0C52C26EA61000760CA /* FortuneResponseHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FortuneResponseHistory.swift; sourceTree = "<group>"; };
 		4371F5952C2467F7002A15EC /* FortuneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FortuneView.swift; sourceTree = "<group>"; };
+		43B95D652C27058200004988 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +67,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B95D692C271AB300004988 /* SDWebImageSwiftUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -111,6 +115,7 @@
 				431646BB2C21C3E5001CF8A7 /* RootView.swift */,
 				435371A12C1FBCDC006E16BB /* ContentView.swift */,
 				4371F5952C2467F7002A15EC /* FortuneView.swift */,
+				43B95D652C27058200004988 /* HistoryView.swift */,
 				431646B92C21C35B001CF8A7 /* PersonalRecordManagement.swift */,
 				4317E9C62C2316DD009F9182 /* FortuneResponse.swift */,
 				4371F5DC2C26B84C002A15EC /* Model */,
@@ -171,6 +176,9 @@
 			dependencies = (
 			);
 			name = "Yumemi-intern-coding-assignment";
+			packageProductDependencies = (
+				43B95D682C271AB300004988 /* SDWebImageSwiftUI */,
+			);
 			productName = "Yumemi-intern-coding-assignment";
 			productReference = 4353719C2C1FBCDC006E16BB /* Yumemi-intern-coding-assignment.app */;
 			productType = "com.apple.product-type.application";
@@ -243,6 +251,9 @@
 				Base,
 			);
 			mainGroup = 435371932C1FBCDC006E16BB;
+			packageReferences = (
+				43B95D672C271AB300004988 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
+			);
 			productRefGroup = 4353719D2C1FBCDC006E16BB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -292,6 +303,7 @@
 				4356E0C42C26BC69000760CA /* PersonalRecordHistory.swift in Sources */,
 				431646BC2C21C3E5001CF8A7 /* RootView.swift in Sources */,
 				4371F5962C2467F7002A15EC /* FortuneView.swift in Sources */,
+				43B95D662C27058200004988 /* HistoryView.swift in Sources */,
 				4317E9C72C2316DD009F9182 /* FortuneResponse.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -651,6 +663,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		43B95D672C271AB300004988 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SDWebImage/SDWebImageSwiftUI.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.0.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		43B95D682C271AB300004988 /* SDWebImageSwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 43B95D672C271AB300004988 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
+			productName = SDWebImageSwiftUI;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 435371942C1FBCDC006E16BB /* Project object */;
 }

--- a/Yumemi-intern-coding-assignment.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Yumemi-intern-coding-assignment.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "b8523c1642f3c142b06dd98443ea7c48343a4dfd",
+        "version" : "5.19.3"
+      }
+    },
+    {
+      "identity" : "sdwebimageswiftui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImageSwiftUI.git",
+      "state" : {
+        "revision" : "b7af5e6bd9c2987e41730400d1baad13d74a141a",
+        "version" : "3.0.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Yumemi-intern-coding-assignment.xcodeproj/xcuserdata/harukiwatanabe.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Yumemi-intern-coding-assignment.xcodeproj/xcuserdata/harukiwatanabe.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -52,37 +52,5 @@
             </Locations>
          </BreakpointContent>
       </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "FBFF40A0-8BF7-4076-A991-5D371F95331D"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "Yumemi-intern-coding-assignment/ContentView.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "91"
-            endingLineNumber = "91"
-            landmarkName = "sendInfo(input:birthday:selectedBloodType:completion:)"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "31F9BA0C-104A-4E94-8DD5-48C853C5B205"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "Yumemi-intern-coding-assignment/ContentView.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "118"
-            endingLineNumber = "118"
-            landmarkName = "sendInfo(input:birthday:selectedBloodType:completion:)"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/Yumemi-intern-coding-assignment/ContentView.swift
+++ b/Yumemi-intern-coding-assignment/ContentView.swift
@@ -118,8 +118,10 @@ struct ContentView: View {
 
         // JSONシリアライズを試行
         do {
+            print("Request Body: \(body)") // デバッグ用にボディを出力
             request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
         } catch {
+            print("JSON Serialization Error: \(error.localizedDescription)") // エラーを出力
             completion(.failure(error)) // シリアライズエラーを返す
             return
         }
@@ -152,8 +154,9 @@ struct ContentView: View {
         task.resume() // タスクを開始
     }
 
+
     private func save(input: PersonalRecord, birthday: Birthday, selectedBloodType: BloodType, responseMessage: FortuneResponse) {
-        var id: Int = UUID().hashValue
+        let id: Int = UUID().hashValue
         
         //PersonalRecordHistoryに保存
         let today = Calendar.current.dateComponents([.year, .month, .day], from: Date())

--- a/Yumemi-intern-coding-assignment/HistoryView.swift
+++ b/Yumemi-intern-coding-assignment/HistoryView.swift
@@ -1,0 +1,89 @@
+//
+//  HistoryView.swift
+//  Yumemi-intern-coding-assignment
+//
+//  Created by 渡邉華輝 on 2024/06/22.
+//
+
+import Foundation
+import SwiftUI
+import SwiftData
+import SDWebImageSwiftUI
+
+struct HistoryView: View {
+    // @Queryプロパティラッパーを使用して、データベースからPersonalRecordHistoryのレコードを取得
+    @Query(sort: \PersonalRecordHistory.today, order: .reverse) private var personalRecords: [PersonalRecordHistory]
+    // @Queryプロパティラッパーを使用して、データベースからFortuneResponseHistoryのレコードを取得
+    @Query(sort: \FortuneResponseHistory.name) private var fortuneResponses: [FortuneResponseHistory]
+
+    var body: some View {
+        NavigationStack {
+            VStack {
+                // タイトルの表示
+                Text("占い履歴！")
+                    .font(.title)
+                    .padding()
+
+                // リストビューの表示
+                List {
+                    /*
+                    // Personal Recordsセクション
+                    Section(header: Text("Personal Records")) {
+                        // personalRecordsの各レコードを表示
+                        ForEach(personalRecords) { record in
+                            VStack(alignment: .leading) {
+                                Text(record.name) // 名前の表示
+                                    .font(.headline)
+                                Text("Birthday: \(record.year)-\(record.month)-\(record.day)") // 誕生日の表示
+                                Text("Blood Type: \(record.bloodType)") // 血液型の表示
+                                Text("Saved on: \(record.today)") // 保存日付の表示
+                            }
+                        }
+                    }
+                     
+                    */
+
+                    // Fortune Responsesセクション
+                    Section(header: Text("Fortune Responses")) {
+                        // fortuneResponsesの各レコードを表示
+                        ForEach(fortuneResponses) { response in
+                            VStack(alignment: .leading) {
+                                HStack {
+                                    // 画像の表示
+                                    if let url = URL(string: response.logo_url.absoluteString) {
+                                        WebImage(url: url)
+                                            .onSuccess { image, data, cacheType in
+                                                // 成功時の処理
+                                            }
+                                            .resizable()
+                                            .indicator(.activity) // インジケータを表示
+                                            .frame(width: 100, height: 100)
+                                            .scaledToFit()
+                                    }
+                                    
+                                    Divider() // 縦線の表示
+                                    
+                                    VStack(alignment: .leading) {
+                                        Text(response.name) // 名前の表示
+                                            .font(.headline)
+                                        Text("Capital: \(response.capital)") // 首都の表示
+                                        Text("Has Coast Line: \(response.has_coast_line ? "Yes" : "No")") // 海岸線の有無の表示
+                                        Text("Citizen Day: \(response.CitizenDay_month)/\(response.CitizenDay_day)") // 県民の日の表示
+                                        Text(response.brief) // 簡単な説明の表示
+                                            .lineLimit(3)
+                                    }
+                                }
+                            }
+                            .listRowSeparator(.visible)
+                        }
+                    }
+                }
+                .listStyle(GroupedListStyle()) // グループ化されたリストスタイルを適用
+            }
+        }
+    }
+}
+
+#Preview {
+    HistoryView()
+}

--- a/Yumemi-intern-coding-assignment/RootView.swift
+++ b/Yumemi-intern-coding-assignment/RootView.swift
@@ -23,8 +23,7 @@ struct RootView: View {
                         icon: { Image(systemName: "crown.fill") }
                     )
                 }
-/*
-            FavoriteView()
+            HistoryView()
                 .tag(Tab.favorite)
                 .tabItem {
                     Label(
@@ -32,7 +31,6 @@ struct RootView: View {
                         icon: { Image(systemName: "list.star") }
                     )
                 }
- */
         }
     }
 }

--- a/Yumemi-intern-coding-assignment/Yumemi_intern_coding_assignmentApp.swift
+++ b/Yumemi-intern-coding-assignment/Yumemi_intern_coding_assignmentApp.swift
@@ -12,7 +12,7 @@ import SwiftData
 struct Yumemi_intern_coding_assignmentApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            RootView()
                 .modelContainer(for: [PersonalRecordHistory.self, FortuneResponseHistory.self], inMemory: false)
         }
     }


### PR DESCRIPTION
- RootView占い履歴のTabを作成
- パッケージ「SDWebImageSwiftUI」を追加して非同期の画像表示を簡略化
- Yumemi_intern_coding_assignmentAppで実行するViewをContentViewからRootViewへ変更
- 占い結果の履歴を見れるHistoryViewを作成