### PR TITLE
NavigationLinkをnavigationDestinationに更新

### DIFF
--- a/Yumemi-intern-coding-assignment/Views/ContentView.swift
+++ b/Yumemi-intern-coding-assignment/Views/ContentView.swift
@@ -117,12 +117,8 @@ struct ContentView: View {
                     }
                 }
                 .padding()
-                
-                NavigationLink(
-                    destination: FortuneView(fortune: responseMessage), // 応答メッセージを表示するビュー
-                    isActive: $showingDetail
-                ) {
-                    EmptyView() // 詳細ビューへのナビゲーションリンク
+                .navigationDestination(isPresented: $showingDetail) {
+                    FortuneView(fortune: responseMessage) // 応答メッセージを表示するビュー
                 }
             }
         }


### PR DESCRIPTION
- ContentView内の非推奨のNavigationLinkイニシャライザ`init(destination:isActive:label:)`を`navigationDestination(isPresented:destination:)`に置き換え
- ナビゲーション状態の変更を適切に処理するためにボタンアクションを更新