### PR TITLE
県民の日の表示を修正

### DIFF
--- a/Yumemi-intern-coding-assignment/Views/HistoryView.swift
+++ b/Yumemi-intern-coding-assignment/Views/HistoryView.swift
@@ -77,8 +77,13 @@ struct HistoryView: View {
                                             HStack {
                                                 Text("県民の日:")
                                                     .bold()
-                                                Text("\(response.CitizenDay_month)/\(response.CitizenDay_day)")
-                                                    .foregroundColor(Color.primary)
+                                                if response.CitizenDay_month == 0 || response.CitizenDay_day == 0 {
+                                                    Text("なし")
+                                                        .foregroundColor(Color.primary)
+                                                } else {
+                                                    Text("\(response.CitizenDay_month)/\(response.CitizenDay_day)")
+                                                        .foregroundColor(Color.primary)
+                                                }
                                             }
                                             HStack {
                                                 Text("県庁所在地:")


### PR DESCRIPTION
- 県民の日が無い時、0/0となっていたため、なしと表記するようにした